### PR TITLE
get_remote_hash: Don't use regex!

### DIFF
--- a/autoload/vital/__latest__/VCS/Git/Core.vim
+++ b/autoload/vital/__latest__/VCS/Git/Core.vim
@@ -140,18 +140,15 @@ function! s:get_local_hash(repository, branch) abort " {{{
   return s:_readline(filename)
 endfunction " }}}
 function! s:get_remote_hash(repository, remote, branch) abort " {{{
-  let filename = s:Path.join(a:repository, 'refs', 'remotes', a:remote, a:branch)
+  let target = s:Path.join('refs', 'remotes', a:remote, a:branch)
+  let filename = s:Path.join(a:repository, target)
   let hash = s:_readline(filename)
   if empty(hash)
     " sometime the file is missing
     let filename = s:Path.join(a:repository, 'packed-refs')
-    let packed_refs = join(s:_readfile(filename), "\n")
-    " Note:
-    "   Vim document said '.' does not hit a new line but it is a LIE.
-    "   And the behavior of regexpengine=1 is quite annoying thus the
-    "   following discusting regex is required...
-    let pattern = printf('\v(\w|\s)*\ze\srefs/remotes/%s/%s', a:remote, a:branch)
-    let hash = matchstr(packed_refs, pattern)
+    let packed_refs = filter(s:_readfile(filename),
+                      \      'v:val[0] != "#" && v:val[-'.len(target).':] == target')
+    return get(split(get(packed_refs, 0, '')), 0, '')
   endif
   return hash
 endfunction " }}}

--- a/test/VCS/Git/Core.vimspec
+++ b/test/VCS/Git/Core.vimspec
@@ -243,9 +243,9 @@ Describe VCS.Git.Core
       if !isdirectory(fnamemodify(filename, ':h'))
         call mkdir(fnamemodify(filename, ':h'), 'p')
       endif
-      call writefile(['hash reference'], filename)
+      call writefile(['hash-reference'], filename)
       let ret = s:C.get_remote_hash(repository, 'valid_remote', 'valid_branch')
-      Assert Equals(ret, 'hash reference')
+      Assert Equals(ret, 'hash-reference')
       call delete(filename)
     End
 
@@ -254,11 +254,11 @@ Describe VCS.Git.Core
       call writefile([
             \ '# pack-refs with: peeled fully-peeled',
             \ 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa refs/remotes/valid_remote/master',
-            \ 'hash reference refs/remotes/valid_remote/valid_branch',
+            \ 'hash-reference refs/remotes/valid_remote/valid_branch',
             \ 'cccccccccccccccccccccccccccccccccccccccc refs/remotes/valid_remote/other_branch',
             \], filename)
       let ret = s:C.get_remote_hash(repository, 'valid_remote', 'valid_branch')
-      Assert Equals(ret, 'hash reference')
+      Assert Equals(ret, 'hash-reference')
       call delete(filename)
     End
   End


### PR DESCRIPTION
A significant speedup for `s:get_remote_hash()` in `autoload/vital/__latest__/VCS/Git/Core.vim`. See the commit message for rationale.

BTW: I have a PR for neovim to implement a `grepfile()` function that would make this a bit quicker.

``` vim
let packed_refs = filter(s:_readfile(filename),
                      \      'v:val[-'.len(target).':] == target')
```

would become

``` vim
if exists('*grepfile')
  let packed_refs = grepfile(filename, target)
else
  " same as before
endif
```

but in case the PR doesn't merge and vim doesn't get a patch, I left it out. Still, if either do, I'll want to follow it up.
